### PR TITLE
fix(paginator): reset index on page size change

### DIFF
--- a/packages/common/src/components/paginator/Paginator.vue
+++ b/packages/common/src/components/paginator/Paginator.vue
@@ -89,6 +89,7 @@ export default defineComponent({
   },
   methods: {
     onPageSizeChange() {
+      this.currentIndex = 0;
       this.emitPage();
     },
     onPrev() {


### PR DESCRIPTION
## Description

Issue: #8
Problem:

Ex: If you have a list of 40 results and you are viewing 25 and a time,
navigate to page 2, then change per page to 50 and you are at page 2 of 1.

Solution:

Reset the current index to 0 on page size change.

## Checklist

Please ensure your pull request fulfills the following requirements:

- [ ] The commit messages follow our guidelines ([CONTRIBUTING.md](./CONTRIBUTING.md))
- [ ] Tests for any changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Type

What kind of change does this pull request introduce?

<!-- please check the one that applies using an "x" -->

```
[x] Bug
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other (please describe below)
```

## Breaking Changes

Does this pull request introduce any breaking changes?

<!-- please check the one that applies using an "x" -->

```
[ ] Yes
[x] No
```

<!-- if "Yes", please describe the impact and migration path for existing applications below -->

## Other Information

<!-- please include any additional information that might be helpful during review -->

n/a
