### PR TITLE
feat: move list item class to li

### DIFF
--- a/packages/common/sass/components/_list.scss
+++ b/packages/common/sass/components/_list.scss
@@ -9,7 +9,7 @@
     background: none;
     border-color: $list-border;
     border-style: solid;
-    border-width: 0 0 1px 0;;
+    border-width: 0 0 1px 0;
     box-sizing: border-box;
     color: unset;
     display: block;
@@ -20,8 +20,12 @@
     width: 100%;
 
     &--clickable {
+      border: none;
+      background: none;
       cursor: pointer;
       text-decoration: none;
+      font-size: unset;
+      padding: 0;
 
       &:focus,
       &:hover {

--- a/packages/common/src/components/list/ListItem.vue
+++ b/packages/common/src/components/list/ListItem.vue
@@ -1,7 +1,6 @@
 <template>
-  <li>
+  <li class="list__item">
     <component
-      class="list__item"
       v-bind="$attrs"
       :class="{ 'list__item--clickable': isClickable }"
       :is="component"


### PR DESCRIPTION
Problem: Styles not easily accessible in implementation.

Need to move the class to the li element to be able to change style
easily in implementation.

Add additional style overrides for clickable elements.
